### PR TITLE
Sample & Instrument Error Can Be Fixed via Regression

### DIFF
--- a/graconMusic.py
+++ b/graconMusic.py
@@ -228,7 +228,7 @@ def writeOutputFile( outFile, mod ):
   writeSequence( outFile, mod['sequence'] )
   patternPointers = writePatterns( outFile, mod['patterns'] )
   writePatternPointers( outFile, patternPointers['patterns'] )
-  samplePointers = writeSamples2( outFile, patternPointers['end'], mod['instruments'] )
+  samplePointers = writeSamples( outFile, patternPointers['end'], mod['instruments'] )
   writeInstruments( outFile, samplePointers, mod['instruments'] )
   
 
@@ -339,7 +339,7 @@ def convertInstrument( inputInstrument ):
     'repeatStart'	: paddedInstrument['repeatStart'],
     'repeatFlag'	: paddedInstrument['repeatFlag'],
     'adsr' : inputInstrument['adsr'],
-    'samples'		: convertInstrumentSamples2( paddedInstrument['samples'], paddedInstrument['repeatStart'], paddedInstrument['repeatFlag'] )
+    'samples'		: convertInstrumentSamples( paddedInstrument['samples'], paddedInstrument['repeatStart'], paddedInstrument['repeatFlag'] )
   }
 
 def multiplyInstrumentResolution( inputInstrument, factor ):


### PR DESCRIPTION
The older versions of the sample and instrument converters can be temporarily used instead of the newer versions, as the newer versions don't seem to work at all and the older versions still work just fine with all of the _other_ improvements.